### PR TITLE
feat: Rebuild stacked cards animation for projects

### DIFF
--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ExternalLink, Github } from "lucide-react"
-import { motion } from "framer-motion"
+import { StackedCards, StackedCard } from "./stacked-cards";
 
 // Import project images
 import sohanUiUxImage from "@/assets/projects/sohan-uiux.png"
@@ -75,79 +75,77 @@ export function ProjectsSection() {
           </p>
         </div>
 
-        <div className="flex flex-col items-center gap-8">
-          {projects.map((project, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 50 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.6, delay: 0.1 }}
-              className="w-full max-w-4xl"
-            >
-              <Card className="card-hover overflow-hidden group w-full">
-                <div className="md:flex h-full">
-                  <div className="md:w-1/2 relative overflow-hidden">
-                    <img
-                      src={project.image}
-                      alt={project.title}
-                      className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-                    />
-                    <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-                      <div className="flex gap-4">
-                        <Button size="sm" asChild>
-                          <a
-                            href={project.liveUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <ExternalLink className="mr-2 h-4 w-4" />
-                            Live Demo
-                          </a>
-                        </Button>
-                        <Button variant="outline" size="sm" asChild>
-                          <a
-                            href={project.githubUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <Github className="mr-2 h-4 w-4" />
-                            Code
-                          </a>
-                        </Button>
+        <div className="grid gap-8">
+          {/* All Projects Stacked Cards */}
+          <div className="w-full max-w-4xl mx-auto">
+            <StackedCards>
+              {projects.map((project, index) => (
+                <StackedCard key={index}>
+                  <Card className="card-hover overflow-hidden group w-full h-full">
+                    <div className="md:flex h-full">
+                      <div className="md:w-1/2 relative overflow-hidden">
+                        <img
+                          src={project.image}
+                          alt={project.title}
+                          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        />
+                        <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+                          <div className="flex gap-4">
+                            <Button size="sm" asChild>
+                              <a
+                                href={project.liveUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <ExternalLink className="mr-2 h-4 w-4" />
+                                Live Demo
+                              </a>
+                            </Button>
+                            <Button variant="outline" size="sm" asChild>
+                              <a
+                                href={project.githubUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <Github className="mr-2 h-4 w-4" />
+                                Code
+                              </a>
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="md:w-1/2 flex flex-col justify-center">
+                        <CardHeader>
+                          <CardTitle className="flex items-center justify-between">
+                            {project.title}
+                            {project.featured && (
+                              <Badge variant="secondary">Featured</Badge>
+                            )}
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                          <p className="text-muted-foreground mb-4">
+                            {project.description}
+                          </p>
+                          <div className="flex flex-wrap gap-2">
+                            {project.tags.map((tag) => (
+                              <Badge
+                                key={tag}
+                                variant="outline"
+                                className="tech-badge"
+                              >
+                                {tag}
+                              </Badge>
+                            ))}
+                          </div>
+                        </CardContent>
                       </div>
                     </div>
-                  </div>
-                  <div className="md:w-1/2 flex flex-col justify-center p-6">
-                    <CardHeader>
-                      <CardTitle className="flex items-center justify-between">
-                        {project.title}
-                        {project.featured && (
-                          <Badge variant="secondary">Featured</Badge>
-                        )}
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-muted-foreground mb-4">
-                        {project.description}
-                      </p>
-                      <div className="flex flex-wrap gap-2">
-                        {project.tags.map((tag) => (
-                          <Badge
-                            key={tag}
-                            variant="outline"
-                            className="tech-badge"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
-                      </div>
-                    </CardContent>
-                  </div>
-                </div>
-              </Card>
-            </motion.div>
-          ))}
+                  </Card>
+                </StackedCard>
+              ))}
+            </StackedCards>
+          </div>
         </div>
 
         <div className="text-center mt-12">

--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -1,0 +1,95 @@
+import { motion, useScroll, useTransform } from "framer-motion";
+import React, { useRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const StackedCard = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ children, className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "w-full h-full rounded-2xl bg-card shadow-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+);
+StackedCard.displayName = "StackedCard";
+
+interface StackedCardsContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactElement<CardProps>[];
+  cardHeight?: number;
+}
+
+export const StackedCards: React.FC<StackedCardsContainerProps> = ({
+  children,
+  className,
+  cardHeight = 400,
+  ...props
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ["start start", "end end"],
+  });
+
+  const cards = React.Children.toArray(children) as React.ReactElement<CardProps>[];
+  const cardCount = cards.length;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative", className)}
+      style={{ height: `${cardCount * 100}vh` }}
+      {...props}
+    >
+      <div className="sticky top-1/2 -translate-y-1/2 flex items-center justify-center">
+        {cards.map((card, index) => {
+          const y = useTransform(
+            scrollYProgress,
+            [index / cardCount, (index + 0.5) / cardCount, (index + 1) / cardCount],
+            ["50%", "0%", "-50%"]
+          );
+          const opacity = useTransform(
+            scrollYProgress,
+            [
+              index / cardCount,
+              (index + 0.2) / cardCount,
+              (index + 0.8) / cardCount,
+              (index + 1) / cardCount,
+            ],
+            [0, 1, 1, 0]
+          );
+
+          return (
+            <motion.div
+              key={index}
+              className="absolute w-full"
+              style={{
+                transformOrigin: "center",
+                y,
+                opacity,
+                zIndex: cardCount - index,
+              }}
+            >
+              {React.cloneElement(card, {
+                style: {
+                  height: `${cardHeight}px`,
+                  ...card.props.style,
+                },
+              })}
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export { StackedCard };


### PR DESCRIPTION
This commit completely overhauls the animation in the `StackedCards` component to match the user's specific requirements for a "one after another" scroll effect.

- The animation logic in `src/components/stacked-cards.tsx` has been rewritten.
- The new animation uses `framer-motion`'s `useTransform` to control the `y` and `opacity` properties of each card based on scroll progress.
- Each card now scrolls up from the bottom of the viewport, is fully visible in the center, and then scrolls off the top.
- The scaling effect has been removed to ensure each project is clearly visible.
- The `projects-section.tsx` has been updated to use the new `StackedCards` component without any extra props.