### PR TITLE
Feat: update project card animation and mobile layout

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -53,17 +53,6 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
     [index / cardCount, (index + 0.5) / cardCount, (index + 1) / cardCount],
     [0.8, 1, 0.8]
   );
-  const opacity = useTransform(
-    scrollYProgress,
-    [
-      index / cardCount,
-      (index + 0.2) / cardCount,
-      (index + 0.8) / cardCount,
-      (index + 1) / cardCount,
-    ],
-    [0.8, 1, 1, 0.8]
-  );
-
   return (
     <motion.div
       key={index}
@@ -72,8 +61,7 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
         transformOrigin: "center",
         y,
         scale,
-        opacity,
-        zIndex: cardCount - index,
+        zIndex: index,
       }}
     >
       {React.cloneElement(card, {


### PR DESCRIPTION
This commit introduces two main changes based on user feedback:

1.  **Projects Section Animation:**
    - The scroll-triggered overlay card animation in the 'My Creative Projects' section has been updated.
    - The stacking order is reversed so that cards stack one above another as the user scrolls.
    - The opacity animation is removed, keeping all cards at full opacity throughout the animation.

2.  **Certifications Section Layout:**
    - The carousel now consistently shows 3 cards on mobile devices, while maintaining a responsive layout for tablets (2 cards) and desktops (3 cards).