### PR TITLE
feat: Reverse card animation direction

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -46,7 +46,7 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
   const y = useTransform(
     scrollYProgress,
     [index / cardCount, (index + 0.5) / cardCount, (index + 1) / cardCount],
-    ["50%", "0%", "-50%"]
+    ["-50%", "0%", "50%"]
   );
   const scale = useTransform(
     scrollYProgress,


### PR DESCRIPTION
The card animation in the "My Creative Projects" section has been updated.

Previously, the cards would animate from the bottom up. This has been changed so that the cards now animate from the top down, as requested by the user.

This was achieved by inverting the `y` transform's output range in the `StackedCardItem` component in `src/components/stacked-cards.tsx`.