### PR TITLE
feat: Reverse card stack animation order

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -43,14 +43,23 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
   scrollYProgress,
   cardHeight,
 }) => {
+  const reversedIndex = cardCount - 1 - index;
   const y = useTransform(
     scrollYProgress,
-    [index / cardCount, (index + 0.5) / cardCount, (index + 1) / cardCount],
-    ["-50%", "0%", "50%"]
+    [
+      reversedIndex / cardCount,
+      (reversedIndex + 0.5) / cardCount,
+      (reversedIndex + 1) / cardCount,
+    ],
+    ["50%", "0%", "-50%"]
   );
   const scale = useTransform(
     scrollYProgress,
-    [index / cardCount, (index + 0.5) / cardCount, (index + 1) / cardCount],
+    [
+      reversedIndex / cardCount,
+      (reversedIndex + 0.5) / cardCount,
+      (reversedIndex + 1) / cardCount,
+    ],
     [0.8, 1, 0.8]
   );
   return (


### PR DESCRIPTION
The card animation in the "My Creative Projects" section has been updated to match the user's request.

Previously, the cards would animate from the bottom of the stack to the top. This has been changed so that the card that is visually on top of the stack animates first.

This was achieved by calculating a reversed index within the `StackedCardItem` component and using it to drive the animation, thereby reversing the animation sequence.