### PR TITLE
feat: Update card stack animation and layering

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -62,6 +62,14 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
     ],
     [0.8, 1, 0.8]
   );
+  const zIndex = useTransform(
+    scrollYProgress,
+    [
+      (reversedIndex + 0.5) / cardCount,
+      (reversedIndex + 0.5) / cardCount + 0.001,
+    ],
+    [index, -1]
+  );
   return (
     <motion.div
       key={index}
@@ -70,7 +78,7 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
         transformOrigin: "center",
         y,
         scale,
-        zIndex: index,
+        zIndex,
       }}
     >
       {React.cloneElement(card, {


### PR DESCRIPTION
The card animation in the "My Creative Projects" section has been updated to match the user's detailed requirements.

- The animation order has been reversed, so the card that is visually on top of the stack animates first.
- The layering (`zIndex`) of the cards is now dynamic. As a card animates away, its `zIndex` is lowered, making the next card in the stack appear to slide on top of it.

This provides a more intuitive and polished user experience for the projects section.