### PR TITLE
feat: Refine card stack animation and layering

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -68,7 +68,7 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
       (reversedIndex + 0.5) / cardCount,
       (reversedIndex + 0.5) / cardCount + 0.001,
     ],
-    [index, -1]
+    [index, index - cardCount]
   );
   return (
     <motion.div


### PR DESCRIPTION
The card animation in the "My Creative Projects" section has been further refined to match the user's detailed requirements.

- The animation order is reversed, so the card that is visually on top of the stack animates first.
- The layering (`zIndex`) of the cards is now dynamic. As a card animates away, its `zIndex` is lowered, making the next card in the stack appear to slide on top of it.
- The `zIndex` logic has been made more robust by dropping the outgoing card's `zIndex` to `index - cardCount`, ensuring it always layers behind the rest of the stack.

This provides a more intuitive and polished user experience for the projects section.