### PR TITLE
fix: Finalize card stack animation

### DIFF
--- a/src/components/stacked-cards.tsx
+++ b/src/components/stacked-cards.tsx
@@ -75,7 +75,7 @@ const StackedCardItem: React.FC<StackedCardItemProps> = ({
       key={index}
       className="absolute w-full"
       style={{
-        transformOrigin: "center",
+        transformOrigin: "top center",
         y,
         scale,
         zIndex,


### PR DESCRIPTION
This commit provides the final adjustments to the card stack animation in the "My Creative Projects" section, addressing a subtle visual artifact.

- The `transformOrigin` of the cards is set to `top center`. This ensures that as a card shrinks, it shrinks towards its top edge, preventing a visual "moving back" effect that was occurring.

This change, combined with the previous animation adjustments (reversed order, scale to zero, dynamic zIndex), creates a polished and correct animation that meets all user requirements.